### PR TITLE
Add OneEntry to Headless CMS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@
 - [Pages CMS](https://pagescms.org) - A user-friendly and no-hassle CMS for static site generators.
 - [Sitepins](https://sitepins.com/) - A content management system (CMS) for static site generators makes it easier to manage websites built with tools like Astro, Next.js, and Hugo.
 - [Alinea CMS](https://alineacms.com) - Alinea cms is a Git-based, open-source headless CMS for Next.js, and it allows you to keep your content fully typed in your repository.
+- [OneEntry](https://oneentry.cloud/) - Headless CMS + e-commerce backend with a JavaScript SDK for building Next.js apps (products, pages, orders, users, attributes).
 
 ## Database
 


### PR DESCRIPTION
## Checklist

- [x] I have adhered to the contributing guidelines.
- [x] I have adhered to the code of conduct guidelines.

## Project URL

Website: https://oneentry.cloud  
GitHub: https://github.com/ONEENTRY-PLATFORM

## GitHub Stars

Please see the GitHub organization for repository stars:
https://github.com/ONEENTRY-PLATFORM/nextjs-shop-demo

## Description

This PR adds OneEntry to the **Headless CMS** section.

OneEntry is a headless CMS and e-commerce backend with a JavaScript SDK, designed to work seamlessly with Next.js applications. It provides APIs and SDK for managing products, pages, users, orders, and flexible attribute-based data models.

The goal is to make it easier for Next.js developers to integrate a production-ready backend without building one from scratch.