### PR TITLE
Add ShipAI.today to Next.js boilerplate section

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@
 - [Next Forge](https://www.next-forge.com) - A ready-to-use, production-grade Turborepo template for Next.js applications.
 - [TurboStarter](https://turbostarter.dev) - Web (Next.js), mobile (Expo) and browser extension (WXT) starter kit.
 - [Next.js Web3 Template](https://github.com/abaker42/crypto-shelfy-template) - Next.js TypeScript template with wallet integration + token gated pages.
+- [ShipAI.today](https://shipai.today/) - Next.js AI SaaS boilerplate with auth and billing.
 
 ## Headless CMS
 


### PR DESCRIPTION
## Checklist
- [x] I have adhered to the contributing guidelines.
- [x] I have adhered to the code of conduct guidelines.

## Summary
Add ShipAI.today to the Next.js boilerplate section.

## Boilerplate
- Name: ShipAI.today
- Website: https://shipai.today/
- Tagline: AI SaaS Boilerplate and Next.js Launch Template
- Pricing: 299 USD one-time, unlimited projects
- Affiliate Program: Yes
