### PR TITLE
Add cms-lab to Development Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@
 - [@next/eslint-plugin-next](https://www.npmjs.com/package/@next/eslint-plugin-next) - Next/eslint-plugin help to resolve the error.
 - [@next/bundle-analyzer](https://www.npmjs.com/package/@next/bundle-analyzer) - Analyzer your Next.js bundle size using a Webpack bundle analyzer.
 - [Heroshot](https://github.com/omachala/heroshot) - Screenshot automation CLI for documentation. Define screenshots once in config, regenerate all with one command using Playwright. Includes a Next.js integration.
+- [cms-lab](https://github.com/i-afaqrashid/cms-lab) - CLI that checks headless CMS content against your Next.js routes and fails CI on broken routes, SEO gaps, and content drift.
 
 ## Error Handling
 


### PR DESCRIPTION
Adds cms-lab to the Development Tool section.

cms-lab is an open-source CLI that checks headless CMS content against your Next.js routes and fails CI on broken routes, SEO gaps, and content drift. Works with Prismic, Strapi, Directus, WordPress, Contentful, Sanity, and Payload.

Repo: https://github.com/i-afaqrashid/cms-lab

Entry follows the existing format and is added at the end of the Development Tool section. prettier left the file unchanged; the only awesome-lint findings are pre-existing ("Postgres" spelling) and the fork's missing GitHub topics, neither related to this entry.