### PR TITLE
Rename Neon entry to Neon Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@
 - [PlanetScale](https://planetscale.com/) - MySQL platform built for scale.
 - [MongoDB](https://www.mongodb.com/) - Document database that helps build small and large platforms.
 - [Nhost](https://nhost.io/) - Open-source backend and development platform for building and scaling web and mobile apps.
-- [Neon](https://neon.com/) - Serverless Postgres with autoscaling, database branching, and scale-to-zero.
+- [Neon Postgres](https://neon.com/) - Serverless Postgres with autoscaling, database branching, and scale-to-zero.
 
 ## Authentication and User Management
 


### PR DESCRIPTION
Renames the existing Neon entry in the Database section to Neon Postgres for clarity due to new compute platform. Link and description are unchanged.