### PR TITLE
Add Next Agent Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@
 - [TurboStarter](https://turbostarter.dev) - Web (Next.js), mobile (Expo), and browser extension (WXT) starter kit.
 - [Next.js Web3 Template](https://github.com/abaker42/crypto-shelfy-template) - Next.js TypeScript template with wallet integration + token gated pages.
 - [Neon Auth Next.js Template](https://github.com/neondatabase/neon-auth-nextjs-template) - Starter template for Next.js with Neon Auth, managed authentication that syncs users directly into your Neon Postgres database.
+- [Next Agent Template](https://github.com/moisesvalero/next-agent-template) - Next.js starter template for AI-agent-assisted projects with TypeScript, Tailwind CSS, tests, SEO, and optional Supabase and Sanity setup.
 
 ## Headless CMS
 


### PR DESCRIPTION
## Summary
- Add Next Agent Template to the Next.js boilerplate section.

## Checks
- Validated the template from a fresh clone with pnpm run verify.
- Ran Prettier on README.md in this repo.
- Ran pnpm dlx awesome-lint ./README.md; lint passed with existing spell-check warnings for other entries.