### PR TITLE
Add Turbo Start Sanity to Next.js boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@
 - [TurboStarter](https://turbostarter.dev) - Web (Next.js), mobile (Expo), and browser extension (WXT) starter kit.
 - [Next.js Web3 Template](https://github.com/abaker42/crypto-shelfy-template) - Next.js TypeScript template with wallet integration + token gated pages.
 - [Neon Auth Next.js Template](https://github.com/neondatabase/neon-auth-nextjs-template) - Starter template for Next.js with Neon Auth, managed authentication that syncs users directly into your Neon Postgres database.
+- [Turbo Start Sanity](https://github.com/robotostudio/turbo-start-sanity) - Sanity + Next.js page builder starter with visual editing, live preview, and a Turborepo monorepo structure.
 
 ## Headless CMS
 


### PR DESCRIPTION
Adds [Turbo Start Sanity](https://github.com/robotostudio/turbo-start-sanity) at the end of the Next.js boilerplate section: a free, open source Sanity + Next.js page builder starter with visual editing, live preview, and a Turborepo monorepo structure. MIT licensed, 167 stars, actively maintained by Roboto Studio and the community.

Ran pnpm format (no changes) and pnpm lint; the two lint errors are the missing awesome/awesome-list GitHub topics on my fork, not the README.