### PR TITLE
Add SaaSLaunch to Next.js boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@
 - [Neon Auth Next.js Template](https://github.com/neondatabase/neon-auth-nextjs-template) - Starter template for Next.js with Neon Auth, managed authentication that syncs users directly into your Neon Postgres database.
 - [Turbo Start Sanity](https://github.com/robotostudio/turbo-start-sanity) - Sanity + Next.js page builder starter with visual editing, live preview, and a Turborepo monorepo structure.
 - [Next Agent Template](https://github.com/moisesvalero/next-agent-template) - Next.js starter template for AI-agent-assisted projects with TypeScript, Tailwind CSS, tests, SEO, and optional Supabase and Sanity setup.
+- [SaaSLaunch](https://saaslaunch.dev) - Next.js 14 SaaS starter kit with Supabase auth, Stripe/Dodo subscriptions, shadcn/ui, i18n, and SEO defaults pre-wired.
 
 ## Headless CMS
 


### PR DESCRIPTION
Adds [SaaSLaunch](https://saaslaunch.dev) to the Next.js boilerplate section.

**Description:** SaaSLaunch is a Next.js 14 SaaS starter kit built around Supabase (auth + Postgres + RLS) and Stripe/Dodo Payments. It ships with auth flows, subscription tiers, customer portal, shadcn/ui, i18n, SEO and legal pages pre-wired so a solo developer can launch a paid SaaS in days instead of months.

**Why it fits this list:** Same category as Next.js Enterprise Boilerplate, Create T3 App, Next Forge, TurboStarter, etc. Format follows the existing `[Title](link) - Basic introduction.` template from CONTRIBUTING.md and is appended to the bottom of the section per the contributing rules.

Repository / homepage: https://saaslaunch.dev