### PR TITLE
Add Free Next.js CV Template to Next.js blog template section

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@
 - [Minimalist](https://github.com/frontendweb3/minimalist) - Blog template built with Next.js and Tailwind CSS.
 - [Open Blog](https://github.com/frontendweb3/open-blog) - Blogging template built with Next.js, Tailwind CSS, and markdown.
 - [Blogify](https://github.com/frontendweb3/blogify) - Open-source Next.js blog template designed with Tailwind CSS.
+- [Free Next.js CV Template](https://github.com/cekuu35/free-nextjs-cv-template) - MIT-licensed personal portfolio and CV template built with Next.js 15, Tailwind CSS, and TypeScript; multi-page, single-file config, SSG-ready.
 
 ## Next.js boilerplate
 


### PR DESCRIPTION
## What

Adds **[Free Next.js CV Template](https://github.com/cekuu35/free-nextjs-cv-template)** to the *Next.js blog template* section, alongside the existing Portfolio Starter Kit and other portfolio/blog templates.

## Why it belongs

- **Open source & MIT-licensed** — free for personal and commercial use, no attribution required.
- Built with **Next.js 15 (App Router) + Tailwind CSS v3 + TypeScript** (strict mode, zero `any`).
- Multi-page personal portfolio / CV: Home, About, Portfolio, Blog, Contact — each a dedicated route.
- **Single-file customization** — all content lives in one typed config file.
- **SSG-ready** with a one-click Vercel deploy and a [live demo](https://20-personal-cv.vercel.app).

I've personally built and used this template. It's a genuine, working open-source resource (not a promotion link) and matches the format and quality of the existing entries in this section.

## Checklist
- [x] Added at the end of the relevant section
- [x] Format: `- [title](link) - description.`
- [x] Link works and resource is open-source