### PR TITLE
Add LocalMode UI to Shadcn UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@
 - [Unlumen UI](https://ui.unlumen.com) - Animated, production-ready React components designed for Shadcn UI help you ship faster, learn from real code, and stand out.
 - [Payload Components](https://www.payload-components.xyz/) - MIT shadcn-compatible registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects.
 - [8StarLabs UI](https://ui.8starlabs.com/?utm_source=awesome-nextjs&utm_medium=referral&utm_campaign=directory_listing) - A set of beautifully designed components for developers who want niche, high-utility UI elements that you won't find in standard libraries.
+- [LocalMode UI](https://localmode.ai) - Local-first shadcn registry of 107 AI UI primitives and 36 composed blocks (chat, RAG, transcription, CLIP search) installable via npx shadcn add. Runs models entirely in the browser, no servers or API keys.
 
 ## Animation
 


### PR DESCRIPTION
This PR adds **LocalMode UI** to the Shadcn UI section, alongside other shadcn-compatible registries like Payload Components.

LocalMode UI is an open-source (MIT) shadcn registry of 107 AI UI primitives and 36 composed blocks (chat, RAG, Whisper transcription, CLIP image search) where the models run entirely in the browser. Installable via npx shadcn add, with no servers and no API keys.

- Registry: https://localmode.ai
- Repo: https://github.com/LocalMode-AI/LocalMode
