### PR TITLE
Add Poszo Next.js Security Headers Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@
 - [Next.js Utilities Extension](https://chrome.google.com/webstore/detail/Next.js-utilities-extensio/ffcogmoganomoabikgmcmckdgojnpldo) - Chrome extension that shows the size of Next.js static data without requiring additional setup.
 - [GitHub Web IDE](https://chromewebstore.google.com/detail/github-web-ide/adjiklnjodbiaioggfpbpkhbfcnhgkfe) - Open any GitHub repositories in an online web (cloud) IDE like VS Code, GitHub Dev, Code Sandbox, Repl.it, Gitpod, etc.
 - [Next Network](https://chromewebstore.google.com/detail/next-network/jfdfcgpbpbbemkmdffgliagfoggdjmmc) - Devtools extension that allows monitoring server-side requests being sent by the local Next.js application.
+- [Poszo Next.js Security Headers Starter](https://github.com/poszothebuilder/poszo-nextjs-security-headers) - Dependency-free security headers starter and production verifier for Next.js deployments.
 
 ## Utility (Others)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Please confirm that this pull request meets the following requirements:

- [x] I adhered to the contributing guidelines: <https://github.com/officialrajdeepsingh/awesome-nextjs/blob/main/CONTRIBUTING.md>.
- [x] I adhered to the CODE OF CONDUCT guidelines: <https://github.com/officialrajdeepsingh/awesome-nextjs/blob/main/CODE_OF_CONDUCT.md>.

## Provide URL (GitHub | GitLab | NPM | JSR | Website)

https://github.com/poszothebuilder/poszo-nextjs-security-headers

## Provide GitHub | GitLab star

0 stars. This is a newly released, free MIT-licensed tool maintained by Poszo; submitting under the guidelines’ unique-project review exception.

## Describe the pull request and what changes you made.

Adds the Poszo Next.js Security Headers Starter to the end of the Development Tool section. It provides dependency-free header configuration examples, a production verifier, report-only CSP guidance, validation commands, rollback guidance, and documented limitations for Next.js deployments.

## Issue number if exit
