### PR TITLE
Fix awesome-lint error in Bklit description

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@
 - [Payload Components](https://www.payload-components.xyz/) - MIT shadcn-compatible registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects.
 - [8StarLabs UI](https://ui.8starlabs.com/?utm_source=awesome-nextjs&utm_medium=referral&utm_campaign=directory_listing) - A set of beautifully designed components for developers who want niche, high-utility UI elements that you won't find in standard libraries.
 - [LocalMode UI](https://localmode.ai) - Local-first shadcn registry of 107 AI UI primitives and 36 composed blocks (chat, RAG, transcription, CLIP search) installable via npx shadcn add. Runs models entirely in the browser, no servers or API keys.
-- [Bklit](https://bklit.com) - Bklit UI is a component library built on top of shadcn/ui to help you build charts and data visualizations more easily.
+- [Bklit](https://bklit.com) - A component library built on top of shadcn/ui for creating charts and data visualizations.
 
 ## Animation
 


### PR DESCRIPTION
## Summary

Removes the repeated item name from the Bklit description, which caused `remark-lint:no-repeat-item-in-description` to fail on the current `main` branch.

## Validation

- `npm run lint` (passes with four existing spelling warnings)
- `npx prettier --check README.md`
- `git diff --check`

This is a one-line lint cleanup; it does not change the link or categorization.