### PR TITLE
Add eziwiki to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@
 - [MDXTS](https://www.mdxts.dev) - The MDXTS is a content & documentation SDK for React and Next.js. It helps to build a documentation website quickly and efficiently.
 - [Mintlify](https://mintlify.com) - Next.js-based platform for documentation sites. Beautiful out of the box, easy to maintain, and built to convert users.
 - [Docusaurus](https://docusaurus.io/) - A tool that enables teams and individuals to easily publish documentation websites.
+- [eziwiki](https://eziwiki.vercel.app/) - Documentation and wiki site generator with wiki links, backlinks and a graph view. Markdown is rendered at build time and exported as a static site.
 
 ## Next.js blog template
 


### PR DESCRIPTION
Adding [eziwiki](https://github.com/i3months/eziwiki) to the Documentation section.

A documentation and wiki site generator built on Next.js. Markdown goes in `content/`, a static site comes out.

What it adds over the generators already listed: `[[wiki links]]` resolved by title or filename, backlinks on every page, and a graph view of how pages connect. Navigation is derived from the folder structure rather than configured. Markdown is rendered at build time, so neither the parser nor the syntax highlighter ships to the browser, and search runs off a prebuilt index.

- Repository: https://github.com/i3months/eziwiki (MIT)
- Live site, built with itself: https://eziwiki.vercel.app
- npm: `npx create-eziwiki my-docs`

Checked against the contributing guidelines: released (on npm), actively maintained, over 100 stars, Next.js based, not paid or subscription-based.