### PR TITLE
Add MailKite SaaS Starter to Next.js boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@
 - [Turbo Start Sanity](https://github.com/robotostudio/turbo-start-sanity) - Sanity + Next.js page builder starter with visual editing, live preview, and a Turborepo monorepo structure.
 - [Next Agent Template](https://github.com/moisesvalero/next-agent-template) - Next.js starter template for AI-agent-assisted projects with TypeScript, Tailwind CSS, tests, SEO, and optional Supabase and Sanity setup.
 - [Kostra](https://kostra.io) - Next.js SaaS boilerplate with authentication, Stripe billing, credit-based usage billing, admin dashboard, and full TypeScript.
+- [MailKite SaaS Starter](https://github.com/mailkite/saas-startup) - Production-ready Next.js 15 SaaS starter with self-contained authentication (Google/GitHub OAuth + email/password, no auth vendor), Stripe subscriptions, teams, Postgres/Drizzle, and a dark-first UI.
 
 ## Headless CMS
 


### PR DESCRIPTION
Adds [MailKite SaaS Starter](https://github.com/mailkite/saas-startup) to the `## Next.js boilerplate` section, appended at the end of the list per the contributing guidelines.

**What it is:** a free, MIT-licensed, production-ready Next.js 15 (App Router) SaaS starter — Stripe subscriptions, team accounts, PostgreSQL on Supabase with Drizzle ORM, and a dark-first dashboard. Live demo: https://saas-startup.mailkite.dev

**What makes it unique** (and why I am submitting it for review under the "unique project" clause in CONTRIBUTING, given it is new and below the 100-star guideline): authentication runs **self-contained inside the app** — Google/GitHub OAuth + email/password via its own JWT/session layer — so there is **no dependency on a hosted auth vendor** (Clerk/Auth0/Supabase Auth). Most boilerplates here either bundle an auth SaaS or rely on one. A developer who clones it adds their own OAuth app and never opens a third-party auth dashboard.

It sits alongside the existing SaaS/boilerplate entries (e.g. Kostra) as the free, open-source, no-vendor-lock-in option. Happy to shorten the description if you prefer. Thanks for maintaining the list!
